### PR TITLE
Add helper to run pytest bench locally, improve variability

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -78,6 +78,12 @@ def test_train(benchmark, device, jit):
   m = Model(device=device, jit=jit)
   benchmark(cuda_sync, m.train, device=='cuda')
 
+@pytest.mark.parametrize('jit',  [True, False], ids=['jit', 'no-jit'])
+@pytest.mark.parametrize('device',  ['cpu', 'cuda'])
+def test_eval(benchmark, device, jit):
+  m = Model(device=device, jit=jit)
+  benchmark(cuda_sync, m.eval, device=='cuda')
+
 if __name__ == '__main__':
   for device in ['cpu', 'cuda']:
     for jit in [True, False]:
@@ -86,3 +92,4 @@ if __name__ == '__main__':
       model, example_inputs = m.get_module()
       model(*example_inputs)
       m.train()
+      m.eval()

--- a/hubconf.py
+++ b/hubconf.py
@@ -63,9 +63,6 @@ class Model:
       torch.nn.utils.clip_grad_norm_(self.model.parameters(), 3.0)
       self.opt.step()
 
-  def eval(self, niter=1):
-    pass
-
 if __name__ == '__main__':
   for device in ['cpu', 'cuda']:
     for jit in [True, False]:
@@ -74,4 +71,3 @@ if __name__ == '__main__':
       model, example_inputs = m.get_module()
       model(*example_inputs)
       m.train()
-      m.eval()

--- a/hubconf.py
+++ b/hubconf.py
@@ -54,18 +54,20 @@ class Model:
       return self.model, (words.to(device=self.device).transpose(0, 1),)
 
   def train(self, niter=1):
-    losses = []
-    self.opt.zero_grad()
-    params = self.model(self.words)
-    dist = SentCFG(params, lengths=self.lengths)
-    loss = dist.partition.mean()
-    (-loss).backward()
-    losses.append(loss.detach())
-    torch.nn.utils.clip_grad_norm_(self.model.parameters(), 3.0)
-    self.opt.step()
+    for _ in range(niter):
+      losses = []
+      self.opt.zero_grad()
+      params = self.model(self.words)
+      dist = SentCFG(params, lengths=self.lengths)
+      loss = dist.partition.mean()
+      (-loss).backward()
+      losses.append(loss.detach())
+      torch.nn.utils.clip_grad_norm_(self.model.parameters(), 3.0)
+      self.opt.step()
 
   def eval(self, niter=1):
-    params = self.model(self.words)
+    for _ in range(niter):
+      params = self.model(self.words)
 
 def cuda_sync(func, sync=False):
     func()

--- a/hubconf.py
+++ b/hubconf.py
@@ -74,15 +74,14 @@ def cuda_sync(func, sync=False):
 
 @pytest.mark.parametrize('jit',  [True, False], ids=['jit', 'no-jit'])
 @pytest.mark.parametrize('device',  ['cpu', 'cuda'])
-def test_train(benchmark, device, jit):
-  m = Model(device=device, jit=jit)
-  benchmark(cuda_sync, m.train, device=='cuda')
+class TestBench():
+  def test_train(self, benchmark, device, jit):
+    m = Model(device=device, jit=jit)
+    benchmark(cuda_sync, m.train, device=='cuda')
 
-@pytest.mark.parametrize('jit',  [True, False], ids=['jit', 'no-jit'])
-@pytest.mark.parametrize('device',  ['cpu', 'cuda'])
-def test_eval(benchmark, device, jit):
-  m = Model(device=device, jit=jit)
-  benchmark(cuda_sync, m.eval, device=='cuda')
+  def test_eval(self, benchmark, device, jit):
+    m = Model(device=device, jit=jit)
+    benchmark(cuda_sync, m.eval, device=='cuda')
 
 if __name__ == '__main__':
   for device in ['cpu', 'cuda']:


### PR DESCRIPTION
Preparing the train batch and putting it on the device transposed before starting the clock removes most of the variability in the benchmark.